### PR TITLE
1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 dbrennand
+Copyright (c) 2022 dbrennand
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Example usage of the `-Topics` parameter:
 .\Wallie-Pwsh.ps1 -Topics "Fish","Space","Trains","Jets" -AccessKeyFile ".\AccessKey.txt" -Verbose
 ```
 
-If the `-Topics` parameter is not provided, then Wallie-Pwsh will query the `/photos/random` API endpoint for random images.
+If the `-Topics` parameter is not provided, Wallie-Pwsh will query the `/photos/random` API endpoint for random images.
 
 ### Updating the Desktop Wallpaper at Log In
 

--- a/README.md
+++ b/README.md
@@ -8,50 +8,61 @@ Wallie-Pwsh can update your desktop wallpaper on Windows 10 🖥️
 
 2. Copy the **Access Key**.
 
-3. Launch a PowerShell console as administrator.
+3. Launch a PowerShell terminal as administrator.
 
-4. Run the following command to produce a base64 encoded string representation of your Unsplash API access key:
+4. Clone the repository:
 
     ```powershell
-    # Wallie-Pwsh currently requires that you supply the Unsplash API access key as a base64 encoded string
-    # This command will produce a base64 encoded string of your access key
-    [System.Convert]::ToBase64String([System.Text.Encoding]::UNICODE.GetBytes("Enter access key here."))
+    git clone https://github.com/dbrennand/Wallie-Pwsh.git; cd Wallie-Pwsh
     ```
 
-5. When running [Wallie-Pwsh.ps1](Wallie-Pwsh.ps1) provide your base64 encoded access key to the `-AccessKey` parameter.
+5. Create an `AccessKey.txt` file containing your Unsplash access key in encrypted format:
+
+    ```powershell
+    # Run the command below to stop the Unsplash access key from being logged in PSReadline history
+    # Set-PSReadlineOption -HistorySaveStyle SaveNothing
+    $UnsplashAccessKeySecureString = ConvertTo-SecureString -String "<Unsplash access key>" -AsPlainText -Force
+    $Cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "Wallie-Pwsh",$UnsplashAccessKeySecureString
+    $Cred.Password | ConvertFrom-SecureString | Out-File -FilePath "$(pwd)\AccessKey.txt" -Force
+    ```
 
 ## Usage
 
-Wallie-Pwsh has an optional parameter to supply topics using the `-Topics` parameter.
-When supplied, one will be chosen at random and used in the query to the Unsplash API.
+Wallie-Pwsh has an optional parameter to supply topics using `-Topics`.
+When supplied, a topic will be chosen at random and used in the query to the Unsplash API.
 
 Example usage of the `-Topics` parameter:
 
 ```powershell
-.\Wallie-Pwsh.ps1 -Topics "Fish","Space","Trains","Jets" -AccessKey "Base64 encoded access key." -Verbose
+.\Wallie-Pwsh.ps1 -Topics "Fish","Space","Trains","Jets" -AccessKeyFile ".\AccessKey.txt" -Verbose
 ```
 
 If the `-Topics` parameter is not provided, then Wallie-Pwsh will query the `/photos/random` API endpoint for random images.
 
-### Running periodically
+### Updating the Desktop Wallpaper at Log In
 
-A use case for this script is to run it using Windows Task Scheduler.
+A use case for Wallie-Pwsh is to run it using Windows Task Scheduler at log in.
 
 > [!NOTE]
-> Ensure you enter the correct path to [Wallie-Pwsh.ps1](Wallie-Pwsh.ps1) and provide a base64 encoded access key.
+>
+> Make sure you enter the correct absolute paths to the [Wallie-Pwsh.ps1](Wallie-Pwsh.ps1) script and Unsplash access key file (using the `-AccessKeyFile` parameter).
+>
+> To get the absolute paths, run the following command in the Wallie-Pwsh directory:
+> ```powershell
+> (Get-ChildItem | Where-Object -FilterScript { $_.Name -match "AccessKey|Wallie" }).FullName
+> ```
 
-1. Launch a PowerShell console as administrator.
+Configure Windows Task Scheduler to execute Wallie-Pwsh at log in:
 
-2. Run the following commands to execute Wallie-Pwsh at user log in:
+> [!NOTE]
+>
+> Replace the values of the `-Topics` parameter in the command below or remove it.
 
-    > [!NOTE]
-    > Replace the values of the `-Topics` parameter or remove it (if you desire a random image not based on a topic).
-
-    ```powershell
-    $Task = New-ScheduledTaskAction -Execute "PowerShell.exe" -Argument '-NoProfile -WindowStyle "Hidden" -ExecutionPolicy "Bypass" -Command absolute\path\to\Wallie-Pwsh.ps1 -Topics "Mountain","Space","Trains" -AccessKey "Base64 encoded access key." -Verbose'
-    $Trigger = New-ScheduledTaskTrigger -AtLogOn
-    Register-ScheduledTask -RunLevel "Highest" -Action $Task -Trigger $Trigger -TaskName "Wallie-Pwsh" -Description "Updates the desktop wallpaper at user log in."
-    ```
+```powershell
+$Task = New-ScheduledTaskAction -Execute "PowerShell.exe" -Argument '-NoProfile -WindowStyle "Hidden" -ExecutionPolicy "Bypass" -Command absolute\path\to\Wallie-Pwsh.ps1 -Topics "Mountain","Space","Trains" -AccessKeyFile "absolute\path\to\AccessKey.txt" -Verbose'
+$Trigger = New-ScheduledTaskTrigger -AtLogOn
+Register-ScheduledTask -RunLevel "Highest" -Action $Task -Trigger $Trigger -TaskName "Wallie-Pwsh" -Description "Updates the desktop wallpaper at log in."
+```
 
 ## Authors -- Contributors
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Wallie-Pwsh can update your desktop wallpaper on Windows 10 🖥️
 5. Create an `AccessKey.txt` file containing your Unsplash access key in encrypted format:
 
     ```powershell
-    # Run the command below to stop the Unsplash access key from being logged in PSReadline history
+    # Run the command below to stop the Unsplash access key being logged in PSReadline history
     # Set-PSReadlineOption -HistorySaveStyle SaveNothing
     $UnsplashAccessKeySecureString = ConvertTo-SecureString -String "<Unsplash access key>" -AsPlainText -Force
     $Cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "Wallie-Pwsh",$UnsplashAccessKeySecureString

--- a/Wallie-Pwsh.ps1
+++ b/Wallie-Pwsh.ps1
@@ -28,11 +28,11 @@ SOFTWARE.
     Wallie-Pwsh updates your desktop wallpaper using the Unsplash API.
 
 .PARAMETER Topics
-    If supplied, Wallie-Pwsh will select a user provided topic at random and use this to query an image from the Unsplash API.
+    If supplied, Wallie-Pwsh will select a topic at random and use this to query an image from the Unsplash API.
     Wallie-Pwsh will then select a result from the Unsplash API at random.
 
 .PARAMETER AccessKey
-    A base64 encoded access key used to authenticate with the Unsplash API.
+    A base64 encoded access key used to authenticate to the Unsplash API.
 
 .EXAMPLE
     .\Wallie-Pwsh.ps1 -Topics "Fish","Space","Trains","Jets" `
@@ -42,7 +42,7 @@ SOFTWARE.
     .\Wallie-Pwsh.ps1 -AccessKey "MwAxADgANQAxADIAYQA3AGEAMwBkAGsANABkAGsANQBlADkAOAAwADYAMwA2ADQAMgBmAHYAZAA2ADMANgA5AHMAZABkADkANAA4ADMANwA0AGUAYQAxADYAMQBmAGMAZgAyAG4AZAA3AHkAawA2ADAAYgA1AHYAOQAxAGUAOQA=" -Verbose
 
 .NOTES
-    Ensure you provide the AccessKey parameter as a base64 encoded string. Sadly, security through obscurity.
+    Ensure you provide the -AccessKey parameter as a base64 encoded string. Sadly, security through obscurity.
     If you know a better way of handling this, feel free to submit a PR :-)
 #>
 [CmdletBinding()]
@@ -56,7 +56,7 @@ param (
     $AccessKey
 )
 
-$Version = "0.0.2"
+$Version = "0.1.0"
 
 # Decode base64 encoded AccessKey parameter
 try {

--- a/Wallie-Pwsh.ps1
+++ b/Wallie-Pwsh.ps1
@@ -48,7 +48,7 @@ param (
     $Topics,
 
     [Parameter(Mandatory = $true)]
-    [ValidateScript({ Test-Path -Path $_ -PathType Leaf })]
+    [ValidateScript( { Test-Path -Path $_ -PathType Leaf })]
     [String]
     $AccessKeyFile
 )
@@ -70,7 +70,7 @@ catch {
 try {
     Write-Verbose -Message "Attempting to decrypt Unsplash access key."
     $AccessKeySecureString = $AccessKeyFileContents | ConvertTo-SecureString
-    $Cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "Wallie",$AccessKeySecureString
+    $Cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "Wallie", $AccessKeySecureString
     $AccessKey = $Cred.GetNetworkCredential().Password
 }
 catch {

--- a/Wallie-Pwsh.ps1
+++ b/Wallie-Pwsh.ps1
@@ -36,10 +36,10 @@ SOFTWARE.
 
 .EXAMPLE
     .\Wallie-Pwsh.ps1 -Topics "Fish","Space","Trains","Jets" `
-        -AccessKeyFile "C:\Users\user\Wallie-Pwsh\AccessKey.txt"
+        -AccessKeyFile "C:\Users\User\Wallie-Pwsh\AccessKey.txt"
 
 .EXAMPLE
-    .\Wallie-Pwsh.ps1 -AccessKeyFile "C:\Users\user\Wallie-Pwsh\AccessKey.txt" -Verbose
+    .\Wallie-Pwsh.ps1 -AccessKeyFile "C:\Users\User\Wallie-Pwsh\AccessKey.txt" -Verbose
 #>
 [CmdletBinding()]
 param (

--- a/Wallie-Pwsh.ps1
+++ b/Wallie-Pwsh.ps1
@@ -54,7 +54,7 @@ param (
 )
 
 # Declare script version
-$Version = "0.1.0"
+$Version = "1.0.0"
 Write-Verbose -Message "Running Wallie-Pwsh.ps1 version: $($Version)."
 
 # Get encrypted Unsplash access key from file

--- a/Wallie-Pwsh.ps1
+++ b/Wallie-Pwsh.ps1
@@ -1,7 +1,7 @@
 <#
 MIT License
 
-Copyright (c) 2020 dbrennand
+Copyright (c) 2022 dbrennand
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Wallie-Pwsh.ps1
+++ b/Wallie-Pwsh.ps1
@@ -31,19 +31,15 @@ SOFTWARE.
     If supplied, Wallie-Pwsh will select a topic at random and use this to query an image from the Unsplash API.
     Wallie-Pwsh will then select a result from the Unsplash API at random.
 
-.PARAMETER AccessKey
-    A base64 encoded access key used to authenticate to the Unsplash API.
+.PARAMETER AccessKeyFile
+    The absolute path to the file containing the encrypted Unsplash access key.
 
 .EXAMPLE
     .\Wallie-Pwsh.ps1 -Topics "Fish","Space","Trains","Jets" `
-        -AccessKey "MwAxADgANQAxADIAYQA3AGEAMwBkAGsANABkAGsANQBlADkAOAAwADYAMwA2ADQAMgBmAHYAZAA2ADMANgA5AHMAZABkADkANAA4ADMANwA0AGUAYQAxADYAMQBmAGMAZgAyAG4AZAA3AHkAawA2ADAAYgA1AHYAOQAxAGUAOQA=" -Verbose
+        -AccessKeyFile "C:\Users\user\Wallie-Pwsh\AccessKey.txt"
 
 .EXAMPLE
-    .\Wallie-Pwsh.ps1 -AccessKey "MwAxADgANQAxADIAYQA3AGEAMwBkAGsANABkAGsANQBlADkAOAAwADYAMwA2ADQAMgBmAHYAZAA2ADMANgA5AHMAZABkADkANAA4ADMANwA0AGUAYQAxADYAMQBmAGMAZgAyAG4AZAA3AHkAawA2ADAAYgA1AHYAOQAxAGUAOQA=" -Verbose
-
-.NOTES
-    Ensure you provide the -AccessKey parameter as a base64 encoded string. Sadly, security through obscurity.
-    If you know a better way of handling this, feel free to submit a PR :-)
+    .\Wallie-Pwsh.ps1 -AccessKeyFile "C:\Users\user\Wallie-Pwsh\AccessKey.txt" -Verbose
 #>
 [CmdletBinding()]
 param (
@@ -52,19 +48,33 @@ param (
     $Topics,
 
     [Parameter(Mandatory = $true)]
+    [ValidateScript({ Test-Path -Path $_ -PathType Leaf })]
     [String]
-    $AccessKey
+    $AccessKeyFile
 )
 
+# Declare script version
 $Version = "0.1.0"
+Write-Verbose -Message "Running Wallie-Pwsh.ps1 version: $($Version)."
 
-# Decode base64 encoded AccessKey parameter
+# Get encrypted Unsplash access key from file
 try {
-    Write-Verbose -Message "Attempting to decode base64 encoded access key."
-    $AccessKey = [System.Text.Encoding]::UNICODE.GetString([System.Convert]::FromBase64String($AccessKey))
+    Write-Verbose -Message "Attempting to get encrypted Unsplash access key from file ""$($AccessKeyFile)""."
+    $AccessKeyFileContents = Get-Content -Path $AccessKeyFile -Verbose:($PSBoundParameters["Verbose"] -eq $true)
 }
 catch {
-    throw "Failed to decode base64 encoded access key."
+    throw "Failed to get encrypted Unsplash access key from file ""$($AccessKeyFile)"":`n$($_.Exception.Message)"
+}
+
+# Decrypt Unsplash access key
+try {
+    Write-Verbose -Message "Attempting to decrypt Unsplash access key."
+    $AccessKeySecureString = $AccessKeyFileContents | ConvertTo-SecureString
+    $Cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "Wallie",$AccessKeySecureString
+    $AccessKey = $Cred.GetNetworkCredential().Password
+}
+catch {
+    throw "Failed to decrypt Unsplash access key from file ""$($AccessKeyFile)"":`n$($_.Exception.Message)"
 }
 
 # Declare Unsplash API random endpoint
@@ -82,7 +92,7 @@ if ($Topics) {
     Write-Verbose -Message "Chosen topic is ""$($Topic)""."
     try {
         Write-Verbose -Message "Attempting to make a web request to the Unsplash API endpoint ""$($UnsplashApiRandomEndpoint)"" using the topic ""$($Topic)""."
-        $JsonResponse = Invoke-RestMethod -Uri $UnsplashApiRandomEndpoint -Method GET -Headers $RequestHeaders -Body @{ "query" = $($Topic); "orientation" = "landscape"; "count" = "30" }
+        $JsonResponse = Invoke-RestMethod -Uri $UnsplashApiRandomEndpoint -Method GET -Headers $RequestHeaders -Body @{ "query" = $($Topic); "orientation" = "landscape"; "count" = "30" } -Verbose:($PSBoundParameters["Verbose"] -eq $true)
     }
     catch {
         throw "Failed to make a web request to the Unsplash API endpoint ""$($UnsplashApiRandomEndpoint)"" using the topic ""$($Topic)"":`n$($_.Exception.Message)"
@@ -93,15 +103,15 @@ else {
     # Query random images from the Unsplash API
     try {
         Write-Verbose -Message "Attempting to make a web request to the Unsplash API endpoint ""$($UnsplashApiRandomEndpoint)"" with no topic."
-        $JsonResponse = Invoke-RestMethod -Uri $UnsplashApiRandomEndpoint -Method GET -Headers $RequestHeaders -Body @{ "orientation" = "landscape"; "count" = "30" }
+        $JsonResponse = Invoke-RestMethod -Uri $UnsplashApiRandomEndpoint -Method GET -Headers $RequestHeaders -Body @{ "orientation" = "landscape"; "count" = "30" } -Verbose:($PSBoundParameters["Verbose"] -eq $true)
     }
     catch {
         throw "Failed to make a web request to the Unsplash API endpoint ""$($UnsplashApiRandomEndpoint)"" with no topic:`n$($_.Exception.Message)"
     }
 }
 
-# Select a random image from the JsonResponse
-Write-Verbose -Message "Attempting to select a random image from the Unsplash API JSON response."
+# Select a random image from the JSON response
+Write-Verbose -Message "Attempting to select a random image from the JSON response."
 $ImageObject = $JsonResponse | Get-Random
 Write-Verbose -Message "Randomly chosen image object:`n$($ImageObject)."
 # Obtain image download url
@@ -110,12 +120,12 @@ $ImageUrl = $ImageObject.Urls.Raw
 Write-Verbose -Message "Image URL ""$($ImageUrl)""."
 
 # Perform a mock download to the Unsplash API
-# This is required by Unsplash API guidelines
+# Required by Unsplash API guidelines: https://help.unsplash.com/en/articles/2511258-guideline-triggering-a-download
 try {
     Write-Verbose -Message "Attempting to obtain download location URL for the chosen image."
     $ImageDownloadLocation = $ImageObject.Links.Download_Location
     Write-Verbose -Message "Attempting to make a web request to endpoint ""$($ImageDownloadLocation)"" to perform a mock download required by the Unsplash API guidelines."
-    Invoke-RestMethod -Uri $ImageDownloadLocation -Method GET -Headers $RequestHeaders | Out-Null
+    Invoke-RestMethod -Uri $ImageDownloadLocation -Method GET -Headers $RequestHeaders -Verbose:($PSBoundParameters["Verbose"] -eq $true) | Out-Null
 }
 catch {
     throw "Failed to make a web request to the Unsplash API endpoint ""$($ImageDownloadLocation)"":`n$($_.Exception.Message)"
@@ -125,40 +135,47 @@ catch {
 Write-Output -InputObject "Downloading chosen image from the Unsplash API."
 $ImagePath = "$($Env:USERPROFILE)\Documents\TempWallpaper.jpeg"
 try {
-    Write-Verbose -Message "Attempting to download the chosen image using URL ""$($ImageUrl)"" to file path ""$($ImagePath)""."
-    Invoke-WebRequest -Uri $ImageUrl -OutFile $ImagePath
+    Write-Verbose -Message "Attempting to download the chosen image with URL ""$($ImageUrl)"" to file path ""$($ImagePath)""."
+    Invoke-WebRequest -Uri $ImageUrl -Method GET -OutFile $ImagePath -Verbose:($PSBoundParameters["Verbose"] -eq $true)
 }
 catch {
-    throw "Failed to download the chosen image using URL ""$($ImageUrl)"":`n$($_.Exception.Message)"
+    throw "Failed to download the chosen image with URL ""$($ImageUrl)"" to file path ""$($ImagePath)"":`n$($_.Exception.Message)"
 }
 
-# Update the desktop wallpaper
-Write-Verbose -Message "Attempting to update the desktop wallpaper."
 <#
-Credit for the code below comes from Jose Espitia
+Credit for the type definition below comes from Jose Espitia
 https://www.joseespitia.com/2017/09/15/set-wallpaper-powershell-function/
 #>
 $SPI_SETDESKWALLPAPER = 0x14;
 $SPIF_UPDATEINIFILE = 0x00;
-Write-Verbose -Message "Attempting to add required type definition."
-Add-Type -TypeDefinition @"
-using System;
-using System.Runtime.InteropServices;
-
-public class Params
-{
-    [DllImport("User32.dll",CharSet=CharSet.Unicode)]
-    public static extern int SystemParametersInfo (Int32 uAction,
-                                                   Int32 uParam,
-                                                   String lpvParam,
-                                                   Int32 fuWinIni);
-}
-"@
 try {
+    Write-Verbose -Message "Attempting to add type definition."
+    Add-Type -TypeDefinition @"
+    using System;
+    using System.Runtime.InteropServices;
+
+    public class Params
+    {
+        [DllImport("User32.dll",CharSet=CharSet.Unicode)]
+        public static extern int SystemParametersInfo (Int32 uAction,
+                                                       Int32 uParam,
+                                                       String lpvParam,
+                                                       Int32 fuWinIni);
+    }
+"@
+}
+catch {
+    throw "Failed to add type definition:`n$($_.Exception.Message)"
+}
+
+# Update the desktop wallpaper
+try {
+    Write-Output -InputObject "Updating desktop wallpaper."
+    Write-Verbose -Message "Attempting to update desktop wallpaper to image located at ""$($ImagePath)"" using parameters `$SPI_SETDESKWALLPAPER = $($SPI_SETDESKWALLPAPER); `$SPIF_UPDATEINIFILE = $($SPIF_UPDATEINIFILE);."
     [Params]::SystemParametersInfo($SPI_SETDESKWALLPAPER, 0, $ImagePath, $SPIF_UPDATEINIFILE) | Out-Null
 }
 catch {
-    throw "Failed to update desktop wallpaper from downloaded image located at ""$($ImagePath)"" using parameters `$SPI_SETDESKWALLPAPER = 0x14; `$SPIF_UPDATEINIFILE = 0x00;:`n$($_.Exception.Message)"
+    throw "Failed to update desktop wallpaper to image located at ""$($ImagePath)"":`n$($_.Exception.Message)"
 }
-Write-Verbose -Message "Successfully updated wallpaper from downloaded image located at ""$($ImagePath)"" using parameters `$SPI_SETDESKWALLPAPER = 0x14; `$SPIF_UPDATEINIFILE = 0x00;."
+Write-Verbose -Message "Successfully updated desktop wallpaper to image located at ""$($ImagePath)""."
 Write-Output -InputObject "Successfully updated desktop wallpaper."


### PR DESCRIPTION
# 1.0.0

This release contains a breaking change where the old parameter `-AccessKey` has been reworked to `-AccessKeyFile`. 

The reason for this change is so the Unsplash access key can now be stored securely in a file in encrypted format. This replaces the old behaviour of the access key being base64 encoded.

## Other Changes
* Improvements to error handling and verbose outputs.
* Improved README file with new instructions and usage.
* Bump LICENSE year and script version.
